### PR TITLE
Refactor MCP tests to use pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,4 @@ asyncio_mode = "auto"
 testpaths = ["."]
 python_files = "test_*.py"
 python_functions = "test_*"
-markers = [
-    "integration: marks tests as integration tests",
-    "anyio: marks tests as anyio tests",
-]
+markers = ["integration: marks tests as integration tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,16 @@ dependencies = [
     "mcp[cli]>=1.12.4",
     "pydantic>=2.11.7",
     "python-dotenv>=1.1.1",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["."]
+python_files = "test_*.py"
+python_functions = "test_*"
+markers = [
+    "integration: marks tests as integration tests",
+    "anyio: marks tests as anyio tests",
 ]

--- a/test_client.py
+++ b/test_client.py
@@ -7,13 +7,13 @@ import asyncio
 import json
 import logging
 import os
-import subprocess
+
 import sys
 from contextlib import AsyncExitStack
 
+from dotenv import load_dotenv
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
@@ -25,34 +25,49 @@ logger = logging.getLogger(__name__)
 # Test API key for integration testing
 TEST_API_KEY = os.getenv("FATEBOOK_API_KEY")
 if TEST_API_KEY is None:
-    raise ValueError("Need FATEBOOK_API_KEY env variable to be set either in .env or the local environment")
+    raise ValueError(
+        "Need FATEBOOK_API_KEY env variable to be set either in .env or the local environment"
+    )
 
 # Test user ID for count forecasts testing (from the test API key user)
 TEST_USER_ID = "cme6dxa8g0001i7g74q4exorm"
 
 
+async def call_tool_and_check_content(session, tool_name, **tool_args):
+    """Helper function to call a tool and return its content, handling common error cases."""
+    try:
+        tool_result = await session.call_tool(tool_name, tool_args)
+    except Exception as e:
+        logger.error(f"Error calling tool {tool_name}: {e}")
+        raise
+
+    if not tool_result.content:
+        raise ValueError(f"No content in {tool_name} response")
+
+    tool_content = tool_result.content[0].text
+    return tool_content
+
+
 async def test_count_forecasts(session):
     """Test the count_forecasts endpoint."""
     print("🔧 Testing count_forecasts...")
-    
+
     try:
         # Since list_questions now returns formatted text instead of JSON,
         # we'll use the hardcoded test user ID that we know works
         user_id = TEST_USER_ID
         print(f"🔍 Using test user ID: {user_id}")
-        
+
         # Test counting forecasts for the test user ID
-        count_result = await session.call_tool("count_forecasts", {
-            "userId": user_id
-        })
-        
-        if not count_result.content:
+        count_content = await call_tool_and_check_content(
+            session, "count_forecasts", userId=user_id
+        )
+
+        if count_content is None:
             print("❌ No content in count_forecasts response")
             return False
-            
-        count_content = count_result.content[0].text
         print(f"📊 Count response: {count_content}")
-        
+
         # Now expecting just an integer response
         try:
             count_value = int(count_content)
@@ -61,7 +76,7 @@ async def test_count_forecasts(session):
         except ValueError:
             print(f"❌ Expected integer response, got: {count_content}")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in count_forecasts test: {e}")
         return False
@@ -70,81 +85,82 @@ async def test_count_forecasts(session):
 async def test_create_edit_and_resolve_question(session):
     """Test the full create -> edit -> resolve question flow."""
     print("🔧 Testing create_question -> edit_question -> resolve_question flow...")
-    
+
     # Step 1: Create a test question
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "MCP Edit Test Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.7,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "edit", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="MCP Edit Test Question",
+            resolveBy=resolve_date,
+            forecast=0.7,
+            apiKey=TEST_API_KEY,
+            tags=["test", "edit", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
         print(f"📝 Create response: {create_content}")
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Step 2: Edit the question
         new_resolve_date = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%d")
-        edit_result = await session.call_tool("edit_question", {
-            "questionId": question_id,
-            "title": "MCP Edit Test Question (UPDATED)",
-            "resolveBy": new_resolve_date,
-            "notes": "This question was updated via MCP integration test",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not edit_result.content:
+        edit_content = await call_tool_and_check_content(
+            session,
+            "edit_question",
+            questionId=question_id,
+            title="MCP Edit Test Question (UPDATED)",
+            resolveBy=new_resolve_date,
+            notes="This question was updated via MCP integration test",
+            apiKey=TEST_API_KEY,
+        )
+
+        if edit_content is None:
             print("❌ No content in edit_question response")
             return False
-            
-        edit_content = edit_result.content[0].text
         print(f"✏️ Edit response: {edit_content}")
-        
+
         # Now expecting a boolean response
         if edit_content.lower() == "true":
             print("✅ Successfully edited question!")
         else:
             print("❌ Question editing failed")
             return False
-        
+
         # Step 3: Resolve the question
-        resolve_result = await session.call_tool("resolve_question", {
-            "questionId": question_id,
-            "resolution": "AMBIGUOUS",
-            "questionType": "BINARY",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not resolve_result.content:
+        resolve_content = await call_tool_and_check_content(
+            session,
+            "resolve_question",
+            questionId=question_id,
+            resolution="AMBIGUOUS",
+            questionType="BINARY",
+            apiKey=TEST_API_KEY,
+        )
+
+        if resolve_content is None:
             print("❌ No content in resolve_question response")
             return False
-            
-        resolve_content = resolve_result.content[0].text
         print(f"✅ Resolve response: {resolve_content}")
-        
+
         # Now expecting a boolean response
         if resolve_content.lower() == "true":
             print("✅ Successfully created, edited, and resolved test question!")
@@ -152,7 +168,7 @@ async def test_create_edit_and_resolve_question(session):
         else:
             print("❌ Question resolution failed")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in create/edit/resolve flow: {e}")
         return False
@@ -161,55 +177,53 @@ async def test_create_edit_and_resolve_question(session):
 async def test_create_and_delete_question(session):
     """Test the full create -> delete question flow."""
     print("🔧 Testing create_question -> delete_question flow...")
-    
+
     # Step 1: Create a test question
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "MCP Delete Test Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.6,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "delete", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="MCP Delete Test Question",
+            resolveBy=resolve_date,
+            forecast=0.6,
+            apiKey=TEST_API_KEY,
+            tags=["test", "delete", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
         print(f"📝 Create response: {create_content}")
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Step 2: Delete the question
-        delete_result = await session.call_tool("delete_question", {
-            "questionId": question_id,
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not delete_result.content:
+        delete_content = await call_tool_and_check_content(
+            session, "delete_question", questionId=question_id, apiKey=TEST_API_KEY
+        )
+
+        if delete_content is None:
             print("❌ No content in delete_question response")
             return False
-            
-        delete_content = delete_result.content[0].text
         print(f"🗑️ Delete response: {delete_content}")
-        
+
         # Now expecting a boolean response
         if delete_content.lower() == "true":
             print("✅ Successfully created and deleted test question!")
@@ -217,7 +231,7 @@ async def test_create_and_delete_question(session):
         else:
             print("❌ Question deletion failed")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in create/delete flow: {e}")
         return False
@@ -226,85 +240,86 @@ async def test_create_and_delete_question(session):
 async def test_create_and_add_comment_question(session):
     """Test the full create -> add_comment -> resolve question flow."""
     print("🔧 Testing create_question -> add_comment -> resolve_question flow...")
-    
+
     # Step 1: Create a test question
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "MCP Comment Test Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.4,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "comment", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="MCP Comment Test Question",
+            resolveBy=resolve_date,
+            forecast=0.4,
+            apiKey=TEST_API_KEY,
+            tags=["test", "comment", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
         print(f"📝 Create response: {create_content}")
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Step 2: Add a comment to the question
-        comment_result = await session.call_tool("add_comment", {
-            "questionId": question_id,
-            "comment": "This is a test comment from the MCP integration test",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not comment_result.content:
+        comment_content = await call_tool_and_check_content(
+            session,
+            "add_comment",
+            questionId=question_id,
+            comment="This is a test comment from the MCP integration test",
+            apiKey=TEST_API_KEY,
+        )
+
+        if comment_content is None:
             print("❌ No content in add_comment response")
             return False
-            
-        comment_content = comment_result.content[0].text
         print(f"💬 Comment response: {comment_content}")
-        
+
         # Now expecting a boolean response
         if comment_content.lower() == "true":
             print("✅ Successfully added comment to question!")
         else:
             print("❌ Adding comment failed")
             return False
-        
+
         # Step 3: Resolve the question
-        resolve_result = await session.call_tool("resolve_question", {
-            "questionId": question_id,
-            "resolution": "NO",
-            "questionType": "BINARY",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not resolve_result.content:
+        resolve_content = await call_tool_and_check_content(
+            session,
+            "resolve_question",
+            questionId=question_id,
+            resolution="NO",
+            questionType="BINARY",
+            apiKey=TEST_API_KEY,
+        )
+
+        if resolve_content is None:
             print("❌ No content in resolve_question response")
             return False
-            
-        resolve_content = resolve_result.content[0].text
         print(f"✅ Resolve response: {resolve_content}")
-        
+
         if resolve_content.lower() == "true":
             print("✅ Successfully created, commented, and resolved test question!")
             return True
         else:
             print("❌ Question resolution failed")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in create/comment/resolve flow: {e}")
         return False
@@ -313,85 +328,82 @@ async def test_create_and_add_comment_question(session):
 async def test_create_and_add_forecast_question(session):
     """Test the full create -> add_forecast -> resolve question flow."""
     print("🔧 Testing create_question -> add_forecast -> resolve_question flow...")
-    
+
     # Step 1: Create a test question
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "MCP Forecast Test Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.3,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "forecast", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="MCP Forecast Test Question",
+            resolveBy=resolve_date,
+            forecast=0.3,
+            apiKey=TEST_API_KEY,
+            tags=["test", "forecast", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
         print(f"📝 Create response: {create_content}")
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Step 2: Add a forecast to the question
-        forecast_result = await session.call_tool("add_forecast", {
-            "questionId": question_id,
-            "forecast": 0.8,
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not forecast_result.content:
+        forecast_content = await call_tool_and_check_content(
+            session, "add_forecast", questionId=question_id, forecast=0.8, apiKey=TEST_API_KEY
+        )
+
+        if forecast_content is None:
             print("❌ No content in add_forecast response")
             return False
-            
-        forecast_content = forecast_result.content[0].text
         print(f"📈 Forecast response: {forecast_content}")
-        
+
         # Now expecting a boolean response
         if forecast_content.lower() == "true":
             print("✅ Successfully added forecast to question!")
         else:
             print("❌ Adding forecast failed")
             return False
-        
+
         # Step 3: Resolve the question
-        resolve_result = await session.call_tool("resolve_question", {
-            "questionId": question_id,
-            "resolution": "YES",
-            "questionType": "BINARY",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not resolve_result.content:
+        resolve_content = await call_tool_and_check_content(
+            session,
+            "resolve_question",
+            questionId=question_id,
+            resolution="YES",
+            questionType="BINARY",
+            apiKey=TEST_API_KEY,
+        )
+
+        if resolve_content is None:
             print("❌ No content in resolve_question response")
             return False
-            
-        resolve_content = resolve_result.content[0].text
         print(f"✅ Resolve response: {resolve_content}")
-        
+
         if resolve_content.lower() == "true":
             print("✅ Successfully created, forecasted, and resolved test question!")
             return True
         else:
             print("❌ Question resolution failed")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in create/forecast/resolve flow: {e}")
         return False
@@ -400,64 +412,65 @@ async def test_create_and_add_forecast_question(session):
 async def test_create_and_resolve_question(session):
     """Test the full create -> resolve question flow."""
     print("🔧 Testing create_question -> resolve_question flow...")
-    
+
     # Step 1: Create a test question
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "MCP Integration Test Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.5,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="MCP Integration Test Question",
+            resolveBy=resolve_date,
+            forecast=0.5,
+            apiKey=TEST_API_KEY,
+            tags=["test", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
         print(f"📝 Create response: {create_content}")
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Step 2: Resolve the question
-        resolve_result = await session.call_tool("resolve_question", {
-            "questionId": question_id,
-            "resolution": "YES",
-            "questionType": "BINARY",
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not resolve_result.content:
+        resolve_content = await call_tool_and_check_content(
+            session,
+            "resolve_question",
+            questionId=question_id,
+            resolution="YES",
+            questionType="BINARY",
+            apiKey=TEST_API_KEY,
+        )
+
+        if resolve_content is None:
             print("❌ No content in resolve_question response")
             return False
-            
-        resolve_content = resolve_result.content[0].text
         print(f"✅ Resolve response: {resolve_content}")
-        
+
         if resolve_content.lower() == "true":
             print("✅ Successfully created and resolved test question!")
             return True
         else:
             print("❌ Question resolution failed")
             return False
-            
+
     except Exception as e:
         print(f"❌ Error in create/resolve flow: {e}")
         return False
@@ -466,228 +479,233 @@ async def test_create_and_resolve_question(session):
 async def test_structured_get_question(session):
     """Test that get_question returns a structured Question object."""
     print("🔧 Testing structured get_question response...")
-    
+
     # First create a question to test with
     try:
         from datetime import datetime, timedelta
+
         resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        
-        create_result = await session.call_tool("create_question", {
-            "title": "Test Structured Response Question",
-            "resolveBy": resolve_date,
-            "forecast": 0.75,
-            "apiKey": TEST_API_KEY,
-            "tags": ["test", "structured", "mcp"]
-        })
-        
-        if not create_result.content:
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="Test Structured Response Question",
+            resolveBy=resolve_date,
+            forecast=0.75,
+            apiKey=TEST_API_KEY,
+            tags=["test", "structured", "mcp"],
+        )
+
+        if create_content is None:
             print("❌ No content in create_question response")
             return False
-            
-        create_content = create_result.content[0].text
-        
+
         # Now expecting a JSON response with id and title
         try:
             create_data = json.loads(create_content)
-            question_id = create_data.get('id')
-            title = create_data.get('title')
-            
+            question_id = create_data.get("id")
+            title = create_data.get("title")
+
             if not question_id:
                 print("❌ No question ID in response")
                 return False
-            
+
             print(f"✅ Created test question with ID: {question_id} and title: {title}")
         except json.JSONDecodeError:
             print(f"❌ Expected JSON response, got: {create_content}")
             return False
-        
+
         # Now test get_question with structured response
-        get_result = await session.call_tool("get_question", {
-            "questionId": question_id,
-            "apiKey": TEST_API_KEY
-        })
-        
-        if not get_result.content:
+        get_content = await call_tool_and_check_content(
+            session, "get_question", questionId=question_id, apiKey=TEST_API_KEY
+        )
+
+        if get_content is None:
             print("❌ No content in get_question response")
             return False
-        
+
         # Check if we got a structured response
-        content = get_result.content[0]
-        
         # MCP always returns TextContent, but for structured responses it's JSON
-        if hasattr(content, 'text'):
-            try:
-                # Try to parse as JSON - if successful, it's structured
-                question_data = json.loads(content.text)
-                print("✅ Received structured JSON response from get_question")
-                
-                # Verify key fields exist (using camelCase as returned by API)
-                required_fields = ['id', 'title', 'type', 'resolved', 'createdAt', 'resolveBy']
-                missing_fields = []
-                for field in required_fields:
-                    if field not in question_data:
-                        missing_fields.append(field)
-                
-                if missing_fields:
-                    print(f"❌ Missing required fields in structured response: {missing_fields}")
-                    return False
-                
-                print(f"📋 Question ID: {question_data.get('id')}")
-                print(f"📋 Title: {question_data.get('title')}")
-                print(f"📋 Type: {question_data.get('type')}")
-                print(f"📋 Resolved: {question_data.get('resolved')}")
-                print(f"📋 Created At: {question_data.get('createdAt')}")
-                print(f"📋 Resolve By: {question_data.get('resolveBy')}")
-                
-                # Check we have nested objects properly formatted
-                if 'forecasts' in question_data and question_data['forecasts']:
-                    print(f"📋 Forecasts: {len(question_data['forecasts'])} forecast(s)")
-                    
-                print("✅ Structured response contains all required fields!")
-                return True
-                
-            except json.JSONDecodeError:
-                # Not JSON, it's a formatted text response
-                print("⚠️ Received formatted text response instead of structured JSON")
-                print(f"Response: {content.text[:200]}...")
+        try:
+            # Try to parse as JSON - if successful, it's structured
+            question_data = json.loads(get_content)
+            print("✅ Received structured JSON response from get_question")
+
+            # Verify key fields exist (using camelCase as returned by API)
+            required_fields = ["id", "title", "type", "resolved", "createdAt", "resolveBy"]
+            missing_fields = []
+            for field in required_fields:
+                if field not in question_data:
+                    missing_fields.append(field)
+
+            if missing_fields:
+                print(f"❌ Missing required fields in structured response: {missing_fields}")
                 return False
-        else:
-            print(f"❌ Unexpected response format: {type(content)}")
+
+            print(f"📋 Question ID: {question_data.get('id')}")
+            print(f"📋 Title: {question_data.get('title')}")
+            print(f"📋 Type: {question_data.get('type')}")
+            print(f"📋 Resolved: {question_data.get('resolved')}")
+            print(f"📋 Created At: {question_data.get('createdAt')}")
+            print(f"📋 Resolve By: {question_data.get('resolveBy')}")
+
+            # Check we have nested objects properly formatted
+            if "forecasts" in question_data and question_data["forecasts"]:
+                print(f"📋 Forecasts: {len(question_data['forecasts'])} forecast(s)")
+
+            print("✅ Structured response contains all required fields!")
+            return True
+
+        except json.JSONDecodeError:
+            # Not JSON, it's a formatted text response
+            print("⚠️ Received formatted text response instead of structured JSON")
+            print(f"Response: {get_content[:200]}...")
             return False
-        
+
         # Clean up - delete the test question
-        await session.call_tool("delete_question", {
-            "questionId": question_id,
-            "apiKey": TEST_API_KEY
-        })
-        
+        await call_tool_and_check_content(
+            session, "delete_question", questionId=question_id, apiKey=TEST_API_KEY
+        )
+
         return True
-        
+
     except Exception as e:
         print(f"❌ Error in structured get_question test: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
 async def test_fatebook_server():
     """Test the Fatebook MCP server by calling list_questions tool."""
-    
+
     print(f"✅ Using test API key: {TEST_API_KEY[:10]}...")
-    
+
     async with AsyncExitStack() as stack:
         # Start the server
         server_params = StdioServerParameters(
-            command="uv", 
-            args=["run", "python", "main.py"],
-            env=None
+            command="uv", args=["run", "python", "main.py"], env=None
         )
-        
-        try:
-            # Connect to server
-            stdio_transport = await stack.enter_async_context(
-                stdio_client(server_params)
-            )
-            read, write = stdio_transport
-            session = await stack.enter_async_context(ClientSession(read, write))
-            
-            print("✅ Connected to Fatebook MCP server")
-            
-            # Initialize the session
-            await session.initialize()
-            
-            # List available tools
-            tools_response = await session.list_tools()
-            print(f"✅ Available tools: {[tool.name for tool in tools_response.tools]}")
-            
-            # Test list_questions tool
-            if "list_questions" not in [tool.name for tool in tools_response.tools]:
-                print("❌ Error: list_questions tool not found")
-                return False
-            
-            # Call the list_questions tool with a limit using test API key
-            print("📡 Calling list_questions tool...")
-            result = await session.call_tool("list_questions", {
-                "limit": 3, 
-                "apiKey": TEST_API_KEY
-            })
-            
-            # Check the result - now expecting structured JSON response
-            list_success = False
-            if result.content:
-                content = result.content[0].text
-                try:
-                    # Parse as JSON - expecting QuestionsList format: {"result": [...]}
-                    response_data = json.loads(content)
-                    
-                    if isinstance(response_data, dict) and "result" in response_data:
-                        questions_data = response_data["result"]
-                        print("✅ Successfully retrieved structured questions list")
-                        print(f"✅ Found {len(questions_data)} questions")
-                        
-                        # Verify structure of first question if any exist
-                        if questions_data:
-                            first_q = questions_data[0]
-                            required_fields = ['id', 'title', 'type', 'resolved', 'createdAt', 'resolveBy']
-                            missing_fields = [field for field in required_fields if field not in first_q]
-                            
-                            if missing_fields:
-                                print(f"❌ Missing required fields in first question: {missing_fields}")
-                                return False
-                            
-                            print(f"📋 First question: '{first_q.get('title')}' - {first_q.get('type')} - {'✅ RESOLVED' if first_q.get('resolved') else '⏳ OPEN'}")
-                        
-                        list_success = True
-                    else:
-                        print(f"❌ Expected dict with 'result' field, got: {type(response_data)} with keys: {list(response_data.keys()) if isinstance(response_data, dict) else 'N/A'}")
-                        return False
-                        
-                except json.JSONDecodeError:
-                    # Fallback: maybe it's still a text response or empty
-                    if "No questions found." in content or content.strip() == "[]":
-                        print("✅ No questions found (empty list)")
-                        list_success = True
-                    else:
-                        print(f"❌ Could not parse JSON response: {content}")
-                        return False
-            else:
-                print("❌ Error: No content in response")
-                return False
-            
-            # Test create and resolve question flow
-            create_resolve_success = await test_create_and_resolve_question(session)
-            
-            # Test create, add forecast, and resolve question flow
-            forecast_success = await test_create_and_add_forecast_question(session)
-            
-            # Test create, add comment, and resolve question flow
-            comment_success = await test_create_and_add_comment_question(session)
-            
-            # Test create, edit, and resolve question flow
-            edit_success = await test_create_edit_and_resolve_question(session)
-            
-            # Test structured get_question response
-            structured_success = await test_structured_get_question(session)
-            
-            # Test count forecasts
-            count_success = await test_count_forecasts(session)
-            
-            # Test create and delete question flow
-            delete_success = await test_create_and_delete_question(session)
-            
-            return list_success and create_resolve_success and forecast_success and comment_success and edit_success and structured_success and count_success and delete_success
-                
-        except Exception as e:
-            print(f"❌ Error during testing: {e}")
+
+        # Connect to server
+        stdio_transport = await stack.enter_async_context(stdio_client(server_params))
+        read, write = stdio_transport
+        session = await stack.enter_async_context(ClientSession(read, write))
+
+        print("✅ Connected to Fatebook MCP server")
+
+        # Initialize the session
+        await session.initialize()
+
+        # List available tools
+        tools_response = await session.list_tools()
+        print(f"✅ Available tools: {[tool.name for tool in tools_response.tools]}")
+
+        # Test list_questions tool
+        if "list_questions" not in [tool.name for tool in tools_response.tools]:
+            print("❌ Error: list_questions tool not found")
             return False
+
+        # Call the list_questions tool with a limit using test API key
+        print("📡 Calling list_questions tool...")
+        content = await call_tool_and_check_content(
+            session, "list_questions", limit=3, apiKey=TEST_API_KEY
+        )
+
+        # Check the result - now expecting structured JSON response
+        list_success = False
+        if content is not None:
+            try:
+                # Parse as JSON - expecting QuestionsList format: {"result": [...]}
+                response_data = json.loads(content)
+
+                if isinstance(response_data, dict) and "result" in response_data:
+                    questions_data = response_data["result"]
+                    print("✅ Successfully retrieved structured questions list")
+                    print(f"✅ Found {len(questions_data)} questions")
+
+                    # Verify structure of first question if any exist
+                    if questions_data:
+                        first_q = questions_data[0]
+                        required_fields = [
+                            "id",
+                            "title",
+                            "type",
+                            "resolved",
+                            "createdAt",
+                            "resolveBy",
+                        ]
+                        missing_fields = [
+                            field for field in required_fields if field not in first_q
+                        ]
+
+                        if missing_fields:
+                            print(f"❌ Missing required fields in first question: {missing_fields}")
+                            return False
+
+                        print(
+                            f"📋 First question: '{first_q.get('title')}' - {first_q.get('type')} - {'✅ RESOLVED' if first_q.get('resolved') else '⏳ OPEN'}"
+                        )
+
+                    list_success = True
+                else:
+                    print(
+                        f"❌ Expected dict with 'result' field, got: {type(response_data)} with keys: {list(response_data.keys()) if isinstance(response_data, dict) else 'N/A'}"
+                    )
+                    return False
+
+            except json.JSONDecodeError:
+                # Fallback: maybe it's still a text response or empty
+                if "No questions found." in content or content.strip() == "[]":
+                    print("✅ No questions found (empty list)")
+                    list_success = True
+                else:
+                    print(f"❌ Could not parse JSON response: {content}")
+                    return False
+        else:
+            print("❌ Error: No content in response")
+            return False
+
+        # Test create and resolve question flow
+        create_resolve_success = await test_create_and_resolve_question(session)
+
+        # Test create, add forecast, and resolve question flow
+        forecast_success = await test_create_and_add_forecast_question(session)
+
+        # Test create, add comment, and resolve question flow
+        comment_success = await test_create_and_add_comment_question(session)
+
+        # Test create, edit, and resolve question flow
+        edit_success = await test_create_edit_and_resolve_question(session)
+
+        # Test structured get_question response
+        structured_success = await test_structured_get_question(session)
+
+        # Test count forecasts
+        count_success = await test_count_forecasts(session)
+
+        # Test create and delete question flow
+        delete_success = await test_create_and_delete_question(session)
+
+        return (
+            list_success
+            and create_resolve_success
+            and forecast_success
+            and comment_success
+            and edit_success
+            and structured_success
+            and count_success
+            and delete_success
+        )
 
 
 async def main():
     """Main test function."""
     print("🚀 Starting Fatebook MCP server integration test...")
-    
+
     success = await test_fatebook_server()
-    
+
     if success:
         print("✅ All tests passed! Fatebook MCP server is working correctly.")
         sys.exit(0)

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,8 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
 ]
 
@@ -79,6 +81,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.4" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 
@@ -135,6 +139,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -214,6 +227,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -277,6 +308,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`test_client` had gotten a bit messy from all our incremental editions. This PR reworks `test_client` to use `pytest` and to different functionalities independently. 