### PR TITLE
Add question resource template with URI parameterization

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,7 +1,7 @@
 # To Dos
 ## For MVP
 - [x] Switch over to structured responses using pydantic
-- [ ] Add resource versions of questions
+- [x] Add resource versions of question
 - [ ] Add instructions for how to set up with Claude Code
 - [ ] Remove null fields from responses to avoid wasting context
 - [x] Clean up test_client.py, since Claude has left it a bit of a mess

--- a/main.py
+++ b/main.py
@@ -139,29 +139,17 @@ async def get_question_resource(question_id: str) -> Question:
         raise ValueError(
             "API key is required (set FATEBOOK_API_KEY environment variable)"
         )
-
     params: ParamsType = {"apiKey": api_key, "questionId": question_id}
-
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                "https://fatebook.io/api/v0/getQuestion", params=params
-            )
-            response.raise_for_status()
-
-            question_data = response.json()
-
-            # Add the ID to the data since the API doesn't return it
-            question_data["id"] = question_id
-
-            # Parse as Question model and return it
-            question = Question(**question_data)
-            return question
-
-    except httpx.HTTPError:
-        raise
-    except Exception:
-        raise
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "https://fatebook.io/api/v0/getQuestion", params=params
+        )
+        response.raise_for_status()
+        question_data = response.json()
+        # Add the ID to the data since the API doesn't return it
+        question_data["id"] = question_id
+        question = Question(**question_data)
+        return question
 
 
 @mcp.tool()

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
-from typing import Any
 import os
+from typing import Any
+
 import httpx
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp import Context
 from dotenv import load_dotenv
-from models import Question, QuestionsResponse, QuestionsList, QuestionReference
+from mcp.server.fastmcp import Context, FastMCP
+
+from models import Question, QuestionReference, QuestionsList, QuestionsResponse
 
 load_dotenv()
 
@@ -124,6 +125,42 @@ async def get_question(ctx: Context, questionId: str, apiKey: str = "") -> Quest
         raise
     except Exception as e:
         await ctx.error(f"Unexpected error occurred: {e}")
+        raise
+
+
+@mcp.resource("question://{question_id}")
+async def get_question_resource(question_id: str) -> Question:
+    """Get detailed information about a specific Fatebook question as a resource
+
+    Provides read-only access to question data for loading into LLM context.
+    """
+    api_key = os.getenv("FATEBOOK_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "API key is required (set FATEBOOK_API_KEY environment variable)"
+        )
+
+    params: ParamsType = {"apiKey": api_key, "questionId": question_id}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://fatebook.io/api/v0/getQuestion", params=params
+            )
+            response.raise_for_status()
+
+            question_data = response.json()
+
+            # Add the ID to the data since the API doesn't return it
+            question_data["id"] = question_id
+
+            # Parse as Question model and return it
+            question = Question(**question_data)
+            return question
+
+    except httpx.HTTPError:
+        raise
+    except Exception:
         raise
 
 

--- a/test_client.py
+++ b/test_client.py
@@ -498,3 +498,86 @@ async def test_create_and_resolve_question():
         assert resolve_content.lower() == "true", (
             f"Question resolution failed: {resolve_content}"
         )
+
+
+@pytest.mark.anyio
+async def test_list_resource_templates():
+    """Test listing available resource templates."""
+    async with create_stdio_mcp_client() as (session, _):
+        # Get available resource templates
+        templates_response = await session.list_resource_templates()
+        available_templates = {
+            str(template.uriTemplate)
+            for template in templates_response.resourceTemplates
+        }
+
+        # Check for our question resource template
+        expected_templates = {"question://{question_id}"}
+
+        for template_uri in expected_templates:
+            assert template_uri in available_templates, (
+                f"Missing resource template: {template_uri}"
+            )
+
+        assert len(available_templates) >= 1, (
+            "Should have at least 1 resource template available"
+        )
+
+
+@pytest.mark.anyio
+async def test_read_question_resource():
+    """Test reading a specific question as a resource."""
+    from datetime import datetime, timedelta
+
+    async with create_stdio_mcp_client(include_tools=True) as (
+        session,
+        available_tools,
+    ):
+        # First create a test question to read as a resource
+        resolve_date = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
+
+        create_content = await call_tool_and_check_content(
+            session,
+            "create_question",
+            title="Resource Template Test Question",
+            resolveBy=resolve_date,
+            forecast=0.65,
+            apiKey=TEST_API_KEY,
+            tags=["resource", "template", "test"],
+        )
+
+        assert create_content is not None, "No content in create_question response"
+
+        # Parse JSON response to get question ID
+        create_data = json.loads(create_content)
+        question_id = create_data.get("id")
+        assert question_id is not None, "No question ID in response"
+
+        # Now read the question as a resource using the template
+        resource_uri = f"question://{question_id}"
+        resource_result = await session.read_resource(resource_uri)
+
+        assert resource_result.contents is not None, "No contents in resource response"
+        assert len(resource_result.contents) > 0, (
+            "Resource response has no content items"
+        )
+
+        # Parse the resource content
+        content_item = resource_result.contents[0]
+        # Resource content comes as TextResourceContents, not TextContent
+        assert hasattr(content_item, "text"), (
+            "Resource content should have text attribute"
+        )
+
+        question_data = json.loads(content_item.text)
+
+        # Verify it's the same question
+        assert question_data["id"] == question_id
+        assert question_data["title"] == "Resource Template Test Question"
+        assert question_data["type"] == "BINARY"
+
+        # Clean up
+        delete_content = await call_tool_and_check_content(
+            session, "delete_question", questionId=question_id, apiKey=TEST_API_KEY
+        )
+        assert delete_content.lower() == "true"


### PR DESCRIPTION
Implements `question://{question_id}` resource template to provide read-only access to individual Fatebook questions for loading into LLM context. Resource templates work with Claude Code and allow efficient question data retrieval without using interactive tools.

- Add get_question_resource() function with URI template support
- Include comprehensive tests for resource template functionality
- Verify resource registration via list_resource_templates()
- Test end-to-end resource reading with real question data
- Update TODOS.md to mark resource implementation as complete

🤖 Generated with [Claude Code](https://claude.ai/code)