### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides integration with [Fatebook](https://fatebook.io), a prediction tracking platform. This server allows AI assistants like Claude to create, manage, and track predictions directly through MCP.
 
+<a href="https://glama.ai/mcp/servers/@an1lam/fatebook-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@an1lam/fatebook-mcp/badge" alt="Fatebook Server MCP server" />
+</a>
+
 ## Features
 
 - **Create Questions**: Make predictions with forecasts (0-100% probability)


### PR DESCRIPTION
This PR adds a badge for the [Fatebook MCP Server](https://glama.ai/mcp/servers/@an1lam/fatebook-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@an1lam/fatebook-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@an1lam/fatebook-mcp/badge" alt="Fatebook Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.