### PR TITLE
Fix test_client run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ FATEBOOK_API_KEY=your-api-key-here
 Run the integration tests to verify your setup:
 
 ```bash
-uv run test_client.py
+uv run pytest test_client.py
 ```
 
 This will test all available endpoints and confirm the server is working correctly.


### PR DESCRIPTION
I just noticed that the test_client command in the README was missing `pytest`. This PR just fixes it so anyone who does try to develop with this won't get confused.