### PR TITLE
Exclude None fields from model responses to reduce token usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,9 @@ uv sync
 # Run the main script
 uv run python main.py
 
+# Run tests
+uv run pytest test_client.py
+
 # Add a new dependency
 uv add <package-name>
 

--- a/src/fatebook_mcp/models.py
+++ b/src/fatebook_mcp/models.py
@@ -1,9 +1,17 @@
-from pydantic import BaseModel, Field, field_validator
-from typing import Optional, List, Literal, Union
 from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
 
 
-class User(BaseModel):
+class SlimBaseModel(BaseModel):
+    """Base model that excludes None fields by default to save context tokens"""
+
+    def model_dump(self, *, exclude_none: bool = True, **kwargs) -> Dict[str, Any]:
+        return super().model_dump(exclude_none=exclude_none, **kwargs)
+
+
+class User(SlimBaseModel):
     """User information for forecasts and comments"""
 
     id: Optional[Union[str, int]] = None
@@ -16,7 +24,7 @@ class User(BaseModel):
         return str(v) if v is not None else v
 
 
-class Tag(BaseModel):
+class Tag(SlimBaseModel):
     """Tag model for question categorization"""
 
     id: Optional[Union[str, int]] = None
@@ -29,7 +37,7 @@ class Tag(BaseModel):
         return str(v) if v is not None else v
 
 
-class Forecast(BaseModel):
+class Forecast(SlimBaseModel):
     """Forecast made on a question"""
 
     id: Optional[Union[str, int]] = None
@@ -51,7 +59,7 @@ class Forecast(BaseModel):
         by_alias = True  # Use aliases when serializing
 
 
-class Comment(BaseModel):
+class Comment(SlimBaseModel):
     """Comment on a question"""
 
     id: Optional[Union[str, int]] = None
@@ -70,7 +78,7 @@ class Comment(BaseModel):
         by_alias = True  # Use aliases when serializing
 
 
-class Question(BaseModel):
+class Question(SlimBaseModel):
     """Fatebook question model with optional fields for detailed responses"""
 
     # Core fields (id is optional since getQuestion doesn't return it)
@@ -184,14 +192,14 @@ class Question(BaseModel):
         return "\n".join(lines)
 
 
-class QuestionsResponse(BaseModel):
+class QuestionsResponse(SlimBaseModel):
     """Response from getQuestions endpoint"""
 
     items: List[Question]
     cursor: Optional[str] = None
 
 
-class QuestionsList(BaseModel):
+class QuestionsList(SlimBaseModel):
     """List of questions for MCP responses - matches expected MCP schema"""
 
     result: List[Question]
@@ -201,7 +209,7 @@ class QuestionsList(BaseModel):
         by_alias = True
 
 
-class QuestionReference(BaseModel):
+class QuestionReference(SlimBaseModel):
     """Minimal question reference with id and title"""
 
     id: str


### PR DESCRIPTION
## Summary
- Introduces `SlimBaseModel` that sets `exclude_none=True` by default in `model_dump()`
- All models now inherit from `SlimBaseModel` instead of `BaseModel`
- Automatically filters out None fields from API responses while preserving option to include them when needed
- Updates CLAUDE.md to include test command in Key Commands section

## Test plan
- [x] Verified that None fields are excluded by default from model responses
- [x] Confirmed that None fields can still be included when explicitly requested with `exclude_none=False`
- [x] All existing tests pass (`uv run pytest test_client.py`)
- [x] Manual testing shows significant reduction in response size (removed ~10-15 null fields per question)

🤖 Generated with [Claude Code](https://claude.ai/code)